### PR TITLE
"import resources_rc" -> "import resources"

### DIFF
--- a/gdrive_provider.py
+++ b/gdrive_provider.py
@@ -39,7 +39,8 @@ from qgis.PyQt.QtCore import QSettings, QTranslator, qVersion, QCoreApplication,
 from qgis.PyQt.QtWidgets import QAction, QDialog, QProgressBar, QDialogButtonBox, QListWidgetItem, QApplication, QTableWidgetItem, QMessageBox
 from qgis.PyQt.QtGui import QIcon, QPixmap, QCursor
 # Initialize Qt resources from file resources.py
-import resources_rc
+# import resources_rc
+import resources
 # Import the code for the dialog
 from .gdrive_provider_dialog import GoogleDriveProviderDialog, accountDialog, comboDialog, importFromIdDialog, internalBrowser, webMapDialog, logger, KEYMAP_TEMPLATE
 from .gdrive_layer import progressBar, GoogleDriveLayer


### PR DESCRIPTION
Fixes an issue loading the plugin at QGIS startup.

ISSUE:
```
Couldn't load plugin 'gdrive_provider' due to an error when calling its classFactory() method 

TypeError: qRegisterResourceData(int, bytes, bytes, bytes): argument 2 has unexpected type 'str' 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/qgis/utils.py", line 334, in _startPlugin
    plugins[packageName] = package.classFactory(iface)
  File "/home/bnhr/.local/share/QGIS/QGIS3/profiles/BNHR/python/plugins/gdrive_provider/__init__.py", line 42, in classFactory
    from .gdrive_provider import Google_Drive_Provider
  File "/usr/lib/python3/dist-packages/qgis/utils.py", line 743, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
  File "/home/bnhr/.local/share/QGIS/QGIS3/profiles/BNHR/python/plugins/gdrive_provider/gdrive_provider.py", line 42, in 
    import resources_rc
  File "/usr/lib/python3/dist-packages/qgis/utils.py", line 743, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
  File "/home/bnhr/.local/share/QGIS/QGIS3/profiles/BNHR/python/plugins/qgis2web/resources_rc.py", line 1251, in 
    qInitResources()
  File "/home/bnhr/.local/share/QGIS/QGIS3/profiles/BNHR/python/plugins/qgis2web/resources_rc.py", line 1242, in qInitResources
    QtCore.qRegisterResourceData(0x01, qt_resource_struct,
TypeError: qRegisterResourceData(int, bytes, bytes, bytes): argument 2 has unexpected type 'str'


Python version: 3.8.2 (default, Apr 27 2020, 15:53:34) [GCC 9.3.0] 
QGIS version: 3.12.3-București București, 8234261527 
```